### PR TITLE
The modal shows always the last contract bug fixed

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -111,20 +111,24 @@ function App() {
                       </Card.Text>
                     </Card.Body>
                   </Card>
-                  {modalContent && <Modal show={!!modalContent} onHide={handleClose} fullscreen={true}>
-                    <Modal.Header closeButton>
-                      <Modal.Title>{modalContent.title}</Modal.Title>
-                    </Modal.Header>
-                    <Modal.Body><pre>{JSON.stringify(modalContent, null, 2)}</pre></Modal.Body>
-                    <Modal.Footer>
-                      <Button variant="secondary" onClick={handleClose}>
-                        Close
-                      </Button>
-                      <Button variant="primary" onClick={handleClose}>
-                        Save Changes
-                      </Button>
-                    </Modal.Footer>
-                  </Modal>}
+                 <Modal show={!!modalContent} onHide={handleClose} fullscreen={true}>
+                 {modalContent && 
+                    <>
+                      <Modal.Header closeButton>
+                        <Modal.Title>{modalContent.title}</Modal.Title>
+                      </Modal.Header>
+                      <Modal.Body><pre>{JSON.stringify(modalContent, null, 2)}</pre></Modal.Body>
+                      <Modal.Footer>
+                        <Button variant="secondary" onClick={handleClose}>
+                          Close
+                        </Button>
+                        <Button variant="primary" onClick={handleClose}>
+                          Save Changes
+                        </Button>
+                      </Modal.Footer>
+                    </>
+                    }
+                  </Modal>
                 </>
               }
               renderResultStats={


### PR DESCRIPTION
When the modal is displayed, it takes the last element of the loop as a reference. Issue: #2 

To fix it, instead of using the state as a boolean, I have used it as a store for the information that will be passed when clicking on the "See more details" button.



This is the logic I have used, it can be improved 😅 :
* If the value is null, don't show the modal, if the value contains data, show it.
To control if the value is not null we can use this statement: [!!value](https://github.com/bipoza/kontrata-react/blob/modal-fix/src/App.js#L114)

![modal-bug-fixed](https://user-images.githubusercontent.com/26112509/137791703-8af5e99d-f238-4d0e-928b-907240e3c558.gif)
